### PR TITLE
Quick fix for CDM Glows incorrectly with more than 1 spell tracked

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -585,10 +585,8 @@ function addon:CheckSpellCooldowns()
                 end
             end
         end
-    end
 
     -- Glow spell icons in EssentialCooldownViewer (CooldownManager)
-    for spellID, spellData in pairs(addon.Spells) do
         if spellData.glowCooldownManager then
             local cdmFrames = cdmSpellFrameCache[spellID]
             if cdmFrames then


### PR DESCRIPTION
This PR fixes the issue of Cooldown Manager glowing incorrectly with more than 1 spell tracked.
The main issue is "shouldGlow" variable that was being calculated in action bar spell loop and then never updated in cdm manager loop.

However, this implementation is still very quick-n-dirty due to the fact that cooldown calculation and glow logic relies on the actionbar cooldown, not the CDM cooldown. (shouldGlow is calculated using action bar button.cooldown:IsShown().

This has the implication that if, for some reason (for example, due to a harm/help macro), player does not have a spell they want to track cooldowns for on his actionbar, it WILL NOT glow up in CDM correctly.

I've tried to poke around to see if cdmFrame has its own cooldown info in there somewhere, but it all seems to be secret and doesnt work in combat. Surely there's something there though - I didnt spend much time.