### PR TITLE
Handle secret stack counts and EllesmereUI action bars

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -16,6 +16,7 @@ addon.events:RegisterEvent("UPDATE_BONUS_ACTIONBAR")
 addon.events:RegisterEvent("UPDATE_VEHICLE_ACTIONBAR")
 addon.events:RegisterEvent("BAG_UPDATE_COOLDOWN")
 addon.events:RegisterEvent("ACTIONBAR_UPDATE_COOLDOWN")
+addon.events:RegisterEvent("ACTIONBAR_PAGE_CHANGED")
 
 local itemSlotCache = {}
 local LCG = LibStub("LibCustomGlow-1.0", true)
@@ -120,9 +121,18 @@ local MAX_ACTION_SLOT = 180
 
 -- ─── Third-party action bar support (Bartender4, Dominos, ElvUI) ─────────────
 
--- Returns the action slot for both Blizzard (.action) and LAB-based (._state_action) buttons
+-- Returns the action slot for Blizzard, LAB-based, and attribute-driven buttons.
 local function GetButtonActionSlot(button)
-    return button._state_action or button.action
+    if button._state_action ~= nil then
+        return button._state_action
+    end
+    if button.GetAttribute then
+        local action = button:GetAttribute("action")
+        if action ~= nil then
+            return action
+        end
+    end
+    return button.action
 end
 
 local thirdPartyButtons = {}
@@ -186,6 +196,15 @@ local function CollectThirdPartyButtons()
                 seen[btn] = true
                 thirdPartyButtons[#thirdPartyButtons + 1] = btn
             end
+        end
+    end
+
+    -- EllesmereUI Action Bars (EABButton1 through EABButton180)
+    for i = 1, MAX_ACTION_SLOT do
+        local btn = _G["EABButton" .. i]
+        if btn and not seen[btn] then
+            seen[btn] = true
+            thirdPartyButtons[#thirdPartyButtons + 1] = btn
         end
     end
 
@@ -408,7 +427,7 @@ function addon:FindButtonsForSlot(slot)
             end
         end
     end
-    -- Third-party action bar addons (Bartender4, Dominos, ElvUI)
+    -- Third-party action bar addons (Bartender4, Dominos, ElvUI, EllesmereUI)
     if thirdPartyDirty then
         CollectThirdPartyButtons()
     end
@@ -784,7 +803,8 @@ end
 -- Hooks
 addon.events:HookScript("OnEvent", function(self, event, ...)
     if event == "PLAYER_SPECIALIZATION_CHANGED" or event == "PLAYER_TALENT_UPDATE" or event == "PLAYER_ENTERING_WORLD" or event ==
-        "UPDATE_OVERRIDE_ACTIONBAR" or event == "UPDATE_BONUS_ACTIONBAR" or event == "UPDATE_VEHICLE_ACTIONBAR" then
+        "UPDATE_OVERRIDE_ACTIONBAR" or event == "UPDATE_BONUS_ACTIONBAR" or event == "UPDATE_VEHICLE_ACTIONBAR" or event ==
+        "ACTIONBAR_PAGE_CHANGED" then
         -- Rebuild the slot snapshot so ACTIONBAR_SLOT_CHANGED can detect real changes
         wipe(actionSlotSnapshot)
         for s = 1, MAX_ACTION_SLOT do

--- a/Core.lua
+++ b/Core.lua
@@ -198,7 +198,8 @@ local STACK_FONT_SIZE = 20
 local STACK_FONT_FLAGS = "OUTLINE"
 
 function addon:ShowStackCount(frame, count)
-    if not count then
+    local countIsSecret = issecretvalue and issecretvalue(count)
+    if not countIsSecret and not count then
         addon:HideStackCount(frame)
         return
     end


### PR DESCRIPTION
## What changed

- Detect whether the stack count is a secret value before testing it for absence.
- Pass secret stack text directly to `FontString:SetText`, while retaining the existing hide behavior for missing non-secret values.
- Discover EllesmereUI Action Bars buttons (`EABButton1` through `EABButton180`).
- Resolve attribute-driven buttons through their secure `action` attribute.
- Invalidate button mappings on `ACTIONBAR_PAGE_CHANGED` so paged EllesmereUI bars keep targeting the correct action slots.

## Why

In WoW 12.x, the applications text read from `BuffIconCooldownViewer` can carry the `Text` secret aspect. Boolean-testing that value with `if not count` raises a secret-value error. The generated Blizzard API documentation marks `FontString:SetText` as `SecretArguments = "AllowedWhenTainted"`, so the value can be forwarded for display without inspecting it.

API reference: https://github.com/Gethe/wow-ui-source/blob/live/Interface/AddOns/Blizzard_APIDocumentationGenerated/SimpleFontStringAPIDocumentation.lua#L633-L641

## Impact

Configured proc stack counts can remain visible on action buttons and Cooldown Manager spell frames when aura information is restricted, without exposing or branching on the secret value.

ProcGlows can also find EllesmereUI Action Bars buttons and repaint the correct button after action-bar page changes. Existing Blizzard, Bartender4, Dominos, and ElvUI handling is unchanged.

## Validation

- `git diff --check`
- `npx --yes luaparse -q Core.lua`

The EllesmereUI mapping path was previously verified in game with the installed addon. A fresh in-game two-stack proc and action-bar paging check is still recommended before merging.
